### PR TITLE
Add 6 unit tests for User model (password hashing, validation, security)

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -13,7 +13,7 @@ export default defineConfig([
     plugins: { js },
     extends: ["js/recommended"],
     languageOptions: {
-      globals: globals.browser,
+      globals: globals.browser, ...globals.node,
     },
   },
 

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -13,12 +13,21 @@ export default defineConfig([
     plugins: { js },
     extends: ["js/recommended"],
     languageOptions: {
-      globals: globals.browser, ...globals.node,
+      globals: {
+        ...globals.browser,
+      },
+    },
+  },
+  {
+    files: ["src/test/**/*.{js,jsx,ts,tsx}"],
+    languageOptions: {
+      globals: {
+        global: "writable",
+      },
     },
   },
 
   tseslint.configs.recommended,
-
   pluginReact.configs.flat.recommended,
 
   {

--- a/client/src/test/LoginPage.test.jsx
+++ b/client/src/test/LoginPage.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"; // add waitFor
 import LoginPage from "../pages/Login/LoginPage";
 
 const mockNavigate = vi.fn();
@@ -8,7 +8,7 @@ vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual("react-router-dom");
   return {
     ...actual,
-    useNavigate: () => mockNavigate
+    useNavigate: () => mockNavigate,
   };
 });
 
@@ -16,37 +16,42 @@ describe("LoginPage", () => {
   beforeEach(() => {
     mockNavigate.mockClear();
     localStorage.clear();
+
+    // Mock fetch to simulate a successful login response
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        user: { email: "test@test.com" },
+      }),
+    });
   });
 
   it("shows validation error if email or password missing", () => {
     render(<LoginPage />);
     fireEvent.click(screen.getByRole("button", { name: "Login" }));
-
     expect(
       screen.getByText("Please enter both email and password")
     ).toBeInTheDocument();
   });
 
-  it("stores user and navigates on valid login", () => {
+  it("stores user and navigates on valid login", async () => {
     render(<LoginPage />);
-
     fireEvent.change(screen.getByLabelText("Email"), {
-      target: { value: "test@test.com" }
+      target: { value: "test@test.com" },
     });
-
     fireEvent.change(screen.getByLabelText("Password"), {
-      target: { value: "password123" }
+      target: { value: "password123" },
     });
-
     fireEvent.click(screen.getByRole("button", { name: "Login" }));
 
-    const stored = JSON.parse(localStorage.getItem("user"));
-    expect(stored.email).toBe("test@test.com");
-    expect(stored.isLoggedIn).toBe(true);
-    expect(mockNavigate).toHaveBeenCalledWith("/search");
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem("user"));
+      expect(stored.email).toBe("test@test.com");
+      expect(stored.isLoggedIn).toBe(true);
+      expect(mockNavigate).toHaveBeenCalledWith("/search");
+    });
   });
 });
-
 /*
 SOURCES:
 - Vitest documentation (mocking + test structure)

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -8,8 +8,8 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/test/setupTests.js"],
-    css: true
-  },
+    css : true, // Enable CSS support in tests
+},
   server: {
     port: 5173,
     proxy: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Cs491-09S2026G2-FinalTake",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/server/app/tests/test_auth.py
+++ b/server/app/tests/test_auth.py
@@ -1,0 +1,86 @@
+"""
+Test suite for User model
+Methodology: Unit testing the User model directly
+with an in-memory SQLite database.
+"""
+import pytest
+from flask import Flask
+from app.models import db as _db
+from app.models.user import User
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    _db.init_app(app)
+    with app.app_context():
+        _db.create_all()
+        yield app
+        _db.drop_all()
+
+
+def test_create_user(app):
+    """User can be created and saved to database"""
+    with app.app_context():
+        user = User(username='testuser', email='test@example.com')
+        user.set_password('mypassword')
+        _db.session.add(user)
+        _db.session.commit()
+        assert user.id is not None
+        assert user.username == 'testuser'
+
+
+def test_password_is_hashed(app):
+    """Password is stored as hash not plaintext"""
+    with app.app_context():
+        user = User(username='hashuser', email='hash@example.com')
+        user.set_password('mypassword')
+        assert user.password_hash != 'mypassword'
+        assert len(user.password_hash) > 50
+
+
+def test_check_password_correct(app):
+    """check_password returns True for correct password"""
+    with app.app_context():
+        user = User(username='checkuser', email='check@example.com')
+        user.set_password('mypassword')
+        assert user.check_password('mypassword') is True
+
+
+def test_check_password_wrong(app):
+    """check_password returns False for wrong password"""
+    with app.app_context():
+        user = User(username='wronguser', email='wrong@example.com')
+        user.set_password('mypassword')
+        assert user.check_password('badpassword') is False
+
+
+def test_to_dict_no_password(app):
+    """to_dict never exposes password data"""
+    with app.app_context():
+        user = User(username='dictuser', email='dict@example.com')
+        user.set_password('mypassword')
+        _db.session.add(user)
+        _db.session.commit()
+        data = user.to_dict()
+        assert 'password' not in data
+        assert 'password_hash' not in data
+        assert data['username'] == 'dictuser'
+
+
+def test_duplicate_email_rejected(app):
+    """Database rejects duplicate emails"""
+    with app.app_context():
+        user1 = User(username='user1', email='same@example.com')
+        user1.set_password('pass1')
+        _db.session.add(user1)
+        _db.session.commit()
+
+        user2 = User(username='user2', email='same@example.com')
+        user2.set_password('pass2')
+        _db.session.add(user2)
+        with pytest.raises(Exception):
+            _db.session.commit()


### PR DESCRIPTION
adds 6 pytest unit tests for the User model covering:

User creation and database persistence
Password hashing (not stored as plaintext)
Password verification (correct and incorrect)
to_dict() never exposes password data
Duplicate email rejection