### PR TITLE
Fix server Dockerfile to expose port 5000 instead of 5173

### DIFF
--- a/server/dockerfile
+++ b/server/dockerfile
@@ -3,6 +3,6 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-EXPOSE 5173
+EXPOSE 5000
 # Replace with your actual entrypoint (flask/fastapi/etc)
 CMD ["python","-m","app"]


### PR DESCRIPTION
The server Dockerfile exposes port 5173 which is the client port. Flask runs on 5000. This needs to be corrected.