### PR TITLE
Add query stripping to search endpoint for edge case handling

### DIFF
--- a/server/app/api_routes.py
+++ b/server/app/api_routes.py
@@ -25,7 +25,7 @@ def search():
     - type: 'movie', 'tv', 'game', 'book', or 'all' (default: 'all')
     - page: page number (default: 1)
     """
-    query = request.args.get('query') or request.args.get('q')
+    query = (request.args.get('query') or request.args.get('q', '')).strip()
     media_type = request.args.get('type', 'all')
     page = request.args.get('page', 1, type=int)
     


### PR DESCRIPTION
The /api/search endpoint does not strip leading/trailing whitespace from the query parameter. Adding .strip() to handle edge cases.